### PR TITLE
whitespace/tab fixes - fixes 728

### DIFF
--- a/feature-detects/audio/loop.js
+++ b/feature-detects/audio/loop.js
@@ -7,4 +7,4 @@
 !*/
 define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
     Modernizr.addTest('audioloop', 'loop' in createElement('audio'));
-}); 
+});

--- a/feature-detects/audio/preload.js
+++ b/feature-detects/audio/preload.js
@@ -7,4 +7,4 @@
 !*/
 define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
     Modernizr.addTest('audiopreload', 'preload' in createElement('audio'));
-}); 
+});

--- a/feature-detects/video/loop.js
+++ b/feature-detects/video/loop.js
@@ -7,4 +7,4 @@
 !*/
 define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
     Modernizr.addTest('videoloop', 'loop' in createElement('video'));
-}); 
+});

--- a/feature-detects/video/preload.js
+++ b/feature-detects/video/preload.js
@@ -7,4 +7,4 @@
 !*/
 define(['Modernizr', 'createElement'], function( Modernizr, createElement ) {
     Modernizr.addTest('videopreload', 'preload' in createElement('video'));
-}); 
+});

--- a/src/load.js
+++ b/src/load.js
@@ -210,7 +210,7 @@ var docElement            = doc.documentElement,
         if ( first ) {
           if ( elem != "img" ) {
             sTimeout( function () {
-                insBeforeObj.removeChild( preloadElem ); 
+                insBeforeObj.removeChild( preloadElem );
               }, 50);
           }
 
@@ -495,7 +495,7 @@ var docElement            = doc.documentElement,
         // the always stuff always loads second.
         always && handleGroup( always );
 
-	// If complete callback is used without loading anything
+  // If complete callback is used without loading anything
         !always && !!testObject['complete'] && handleGroup('');
 
     }


### PR DESCRIPTION
This fixes the reported issue in 728.
The good news is the amount of mixed tabs and trailing whitespace is much
smaller than it was at the time the initial report. The only outstanding
files are from caniuse, and node_modules.
